### PR TITLE
Corrected typo on line 179 vulnserver/lib/models.py

### DIFF
--- a/vulnserver/lib/models.py
+++ b/vulnserver/lib/models.py
@@ -176,7 +176,7 @@ class NamePatterns:
     def get_table_secondary_keywords(self):
         cur_path = os.path.dirname(os.path.abspath(__file__))
         keyword_path = os.path.join(cur_path, 'keywords')
-        if not os.path.is_file(keyword_path):
+        if not os.path.isfile(keyword_path):
             sys.exit("need text file with keywords to generate table and column names")
         with open(keyword_path) as f:
              return [i.strip() for i in f.readlines()]


### PR DESCRIPTION
Corrects a typo in file `vulnserver/lib/models.py` line 179 changed `if not os.path.is_file(keyword_path):` to `if not os.path.isfile(keyword_path):` corrects the error 

```
...
 File "REDACTED/deephack/vulnserver/lib/models.py", line 179, in get_table_secondary_keywords
    if not os.path.is_file(keyword_path):
AttributeError: module 'posixpath' has no attribute 'is_file'
```